### PR TITLE
Fix malformatted header line

### DIFF
--- a/projectile-speedbar.el
+++ b/projectile-speedbar.el
@@ -1,4 +1,4 @@
-;;; projectile-speedbar --- projectile integration for speedbar
+;;; projectile-speedbar.el --- projectile integration for speedbar
 
 ;; Copyright (C) 2014 Anshul Verma
 


### PR DESCRIPTION
This resolves the problem that the existing line cannot be parsed by package-buffer-info, leading to an empty description on MELPA.
