### PR TITLE
follow symlink the same way as projectile

### DIFF
--- a/projectile-speedbar.el
+++ b/projectile-speedbar.el
@@ -139,7 +139,7 @@ Set to nil to disable projectile speedbar. Default is t."
 (defun projectile-speedbar-open-current-buffer-in-tree ()
   (interactive)
   (let* ((root-dir (projectile-project-root))
-         (original-buffer-file-directory (file-name-directory (buffer-file-name)))
+         (original-buffer-file-directory (file-name-directory (projectile-file-truename (buffer-file-name))))
          (relative-buffer-path (car (cdr (split-string original-buffer-file-directory root-dir))))
          (parents (butlast (split-string relative-buffer-path "/")))
          (original-window (get-buffer-window)))


### PR DESCRIPTION
projectile-project-root returns file using file-truename which "is found by chasing symbolic links both at the level of the file and at the level of the directories containing it, until no links are left at any level."
If I have a project in /realpath/project symlinks to ~/project, root-dir will be /realpath/project and original-buffer-file-directory will be ~/project so the relative-buffer-path will be wrong in this case.
