### PR TITLE
Declare sr-speedbar requirement

### DIFF
--- a/projectile-speedbar.el
+++ b/projectile-speedbar.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/anshulverma/projectile-speedbar
 ;; Keywords: project, convenience, speedbar, projectile
 ;; Version: 0.0.1
-;; Package-Requires: ((projectile "0.11.0"))
+;; Package-Requires: ((projectile "0.11.0") (sr-speedbar))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -37,7 +37,7 @@
 ;; of that project as well as expand the tree to show the file in the
 ;; project.
 ;;
-;; Features that might be required by this library:
+;; Features that are required by this library:
 ;;
 ;;  `speedbar' `sr-speedbar' `projectile'
 ;;


### PR DESCRIPTION
projectile-speedbar didn't declare its dependency on sr-speedbar, causing compile errors during installation projectile-speedar and necessitating manual install of sr-speedbar. This PR should cause sr-speedbar to be automatically installed when the user installs projectile-speedbar.
See also http://emacs.stackexchange.com/questions/24080/spacemacs-layer-where-package-order-matters.
