### PR TITLE
Fix changing default-directory.

### DIFF
--- a/projectile-speedbar.el
+++ b/projectile-speedbar.el
@@ -120,6 +120,7 @@ Set to nil to disable projectile speedbar. Default is t."
   (when (and (not (equal root-dir sr-speedbar-last-refresh-dictionary))
              (not (sr-speedbar-window-p)))
     (setq sr-speedbar-last-refresh-dictionary root-dir))
+  (sr-speedbar-select-window)
   (setq default-directory root-dir)
   (speedbar-refresh))
 


### PR DESCRIPTION
If you activate speedbar your current-directory will be changed to project root path.
I think it shouldn't be changed in original window, only in speedbar window.