### PR TITLE
changed projectile-file-truename to file-truename

### DIFF
--- a/projectile-speedbar.el
+++ b/projectile-speedbar.el
@@ -141,7 +141,7 @@ Set to nil to disable projectile speedbar. Default is t."
   (interactive)
   (let* ((root-dir (projectile-project-root))
          (original-buffer-file-directory (file-name-directory
-                                          (projectile-file-truename (buffer-file-name))))
+                                          (file-truename (buffer-file-name))))
          (relative-buffer-path (car (cdr (split-string original-buffer-file-directory
                                                        (regexp-quote root-dir)))))
          (parents (butlast (split-string relative-buffer-path "/")))


### PR DESCRIPTION
This fixes the problem I otherwise get with this error: "Symbol’s function definition is void: projectile-file-truename"

PS - I don't really know what I'm doing, but I'm trying to bumble my way through. Looks like it relates to this issue: https://github.com/anshulverma/projectile-speedbar/issues/13